### PR TITLE
feat(controller): provide roomId on game creation and game over

### DIFF
--- a/src/main/kotlin/sc/gui/controller/ClientController.kt
+++ b/src/main/kotlin/sc/gui/controller/ClientController.kt
@@ -128,7 +128,7 @@ class ClientController: Controller() {
                         appController.changeViewTo(ViewType.GAME)
                     }
                 }
-            }, { result ->
+            }, { room, result ->
                 fire(GameOverEvent(result))
             })
         }


### PR DESCRIPTION
not even sure whether this makes sense, but wanted to put it on record just in case
here's what I think we should do:
- ensure the CancelRequest works (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/228)
- return a new object called GameHandle with the possibility to cancel the game, attach listeners (so the `startNewGame` method doesn't have to handle all that by itself) and stop listening to a game altogether
- make it clear that there is one LobbyManager per Game (didn't notice that until recently)
- fix our weird event propagation by making it more consistent with the backend listeners - which should also use events rather than individual listener interfaces with lots of methods