### PR TITLE
chore(ci): auto-publish releases

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,8 +44,6 @@ jobs:
     - name: Release ${{ github.ref }}
       uses: softprops/action-gh-release@v1
       with:
-        draft: true
-        prerelease: true
         files: build/*.jar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since we can edit the Release after publishing I thought it might as well auto-publish